### PR TITLE
Celery tmpdir fix after reboot

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,10 @@
 ---
 # handlers file for celery-docker
 
-- name: reload systemd
-  become: yes
-  command: systemctl daemon-reload
 
 - name: reload celery-worker
   become: yes
-  service:
+  systemd:
+    daemon_reload: yes
     name: celery-worker.service
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,9 @@
 ---
 # handlers file for celery-docker
 
+- name: create celery-worker tmpfiles
+  become: yes
+  command: systemd-tmpfiles --create /etc/tmpfiles.d/celery-worker.conf
 
 - name: reload celery-worker
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,12 +93,12 @@
     dest: "/etc/systemd/system/celery-worker.service"
     src: systemd-system-celery-worker-service.j2
   notify:
-  - reload systemd
   - reload celery-worker
 
 - name: celery docker | enable service
   become: yes
-  service:
+  systemd:
+    daemon_reload: yes
     name: celery-worker.service
     enabled: yes
     state: started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,8 +26,15 @@
     owner: root
   - path: "{{ celery_docker_var_log }}"
     owner: celery
-  - path: "{{ celery_docker_var_run }}"
-    owner: celery
+
+# celery_docker_var_run: /var/run is mounted on tmpfs
+- name: celery docker | var run tmpdir
+  become: yes
+  template:
+    dest: /etc/tmpfiles.d/celery-worker.conf
+    src: tmpfilesd-celery-worker-conf.j2
+  notify:
+  - create celery-worker tmpfiles
 
 # The distribution python-virtualenv is too old
 - name: celery docker | download virtualenv

--- a/templates/tmpfilesd-celery-worker-conf.j2
+++ b/templates/tmpfilesd-celery-worker-conf.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+d {{ celery_docker_var_run }} 755 celery root


### PR DESCRIPTION
The current celery configuration requires a directory under `/var/run/celery`. `/var/run` is a `tmpfs` filesystem on CentOS-7 so this file needs to be recreated automatically.

Tag: `0.1.1`